### PR TITLE
Add Android skeleton with ghost location

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.aymore'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.aymore"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.21"
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.aymore">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="Aymore"
+        android:theme="@style/Theme.Aymore">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/aymore/MainActivity.kt
+++ b/app/src/main/java/com/example/aymore/MainActivity.kt
@@ -1,0 +1,93 @@
+package com.example.aymore
+
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.net.wifi.WifiManager
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
+
+class MainActivity : AppCompatActivity(), OnMapReadyCallback {
+
+    private var map: GoogleMap? = null
+    private var marker: Marker? = null
+    private var ghostMode = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val mapFragment = supportFragmentManager
+            .findFragmentById(R.id.mapFragment) as SupportMapFragment
+        mapFragment.getMapAsync(this)
+
+        findViewById<Button>(R.id.toggleGhostButton).setOnClickListener {
+            ghostMode = !ghostMode
+            if (ghostMode) {
+                injectGhostLocation()
+            } else {
+                disableMock()
+            }
+        }
+    }
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        map = googleMap
+        updateMarker(LatLng(0.0, 0.0))
+    }
+
+    private fun updateMarker(pos: LatLng) {
+        if (marker == null) {
+            marker = map?.addMarker(MarkerOptions().position(pos))
+        } else {
+            marker?.position = pos
+        }
+        map?.moveCamera(CameraUpdateFactory.newLatLngZoom(pos, 16f))
+    }
+
+    private fun injectGhostLocation() {
+        val lm = getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        val provider = LocationManager.GPS_PROVIDER
+        lm.addTestProvider(
+            provider, false, false, false, false, true,
+            true, true, 0, 5
+        )
+        lm.setTestProviderEnabled(provider, true)
+
+        val location = Location(provider).apply {
+            latitude = estimateLatitude()
+            longitude = estimateLongitude()
+            accuracy = 20f
+            time = System.currentTimeMillis()
+        }
+        lm.setTestProviderLocation(provider, location)
+        updateMarker(LatLng(location.latitude, location.longitude))
+    }
+
+    private fun disableMock() {
+        val lm = getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        lm.clearTestProviderEnabled(LocationManager.GPS_PROVIDER)
+    }
+
+    private fun estimateLatitude(): Double {
+        val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val bssid = wifi.connectionInfo.bssid ?: return 0.0
+        // TODO: map BSSID to location using external service
+        return 0.0
+    }
+
+    private fun estimateLongitude(): Double {
+        val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val bssid = wifi.connectionInfo.bssid ?: return 0.0
+        // TODO: map BSSID to location using external service
+        return 0.0
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,21 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <fragment
+            android:id="@+id/mapFragment"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <Button
+            android:id="@+id/toggleGhostButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/toggle_ghost"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_margin="16dp" />
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="white">#FFFFFF</color>
+    <color name="black">#000000</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Aymore</string>
+    <string name="toggle_ghost">Ativar localização fantasma</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Aymore" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'com.android.application' version '8.3.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.21' apply false
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Aymore"
+include(":app")


### PR DESCRIPTION
## Summary
- add basic Android Gradle configuration
- implement simple `MainActivity` with toggle for mock location
- provide initial manifest and resource files for the app

## Testing
- `gradle build` *(fails: Plugin com.android.application not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d71ebb7d083329ab0beade119416b